### PR TITLE
This commit addresses several critical issues that were preventing th…

### DIFF
--- a/packages/bot/src/bot/gateway/llm.py
+++ b/packages/bot/src/bot/gateway/llm.py
@@ -61,10 +61,19 @@ def build_api_request(
     }
     return payload
 
-def is_model_available(model: str) -> Tuple[bool, str]:
-    """Check if a model is available for use. This can be improved to check config."""
-    # This logic can now be smarter by checking loader.PROVIDER_ALLOWED_MODELS
-    return True, ""
+from src.storage.database import MongoDBStore
+
+
+def is_model_available(model: str, db_store: MongoDBStore) -> Tuple[bool, str]:
+    """Check if a model is available in the database."""
+    if db_store.model_exists(model):
+        return True, ""
+
+    supported_models = db_store.get_supported_models()
+    if not supported_models:
+        return False, "There are no models configured in the system."
+
+    return False, f"Model `{model}` is not available. Please choose from: `{'`, `'.join(supported_models)}`"
 
 # --- REWRITTEN CORE FUNCTION ---
 async def call_unified_api(


### PR DESCRIPTION
…e bot from starting correctly and causing user management commands to fail.

The following fixes have been implemented:

- **Sparse Index for `ryuuko_user_id`**: The `DuplicateKeyError` on startup has been resolved by creating a sparse unique index on the `ryuuko_user_id` field in the `user_configs` and `user_memory` collections. This allows multiple documents to have a `null` value for this field without causing a conflict.

- **Missing Database Methods**: The `add_user_credit`, `set_user_credit`, and `set_user_access_level` methods have been added to the `MongoDBStore` class to restore the functionality of the `addcredit`, `setcredit`, and `setlevel` commands.

- **Refactored `is_model_available`**: The `is_model_available` function has been moved to the `gateway` module and now queries the database to check for model availability. The `model` command has been updated to use this new function, resolving the `AttributeError`.

- **Updated Command Logic**: The user commands have been refactored to use the `ryuuko_user_id` instead of the Discord ID, ensuring consistency with the database schema.

- **Test Fixes**: The test suite has been updated to reflect the changes in the command logic, and all tests now pass.